### PR TITLE
Add an auto refresh interval of 50ms to loadkeys and decrypt messages

### DIFF
--- a/discord-e2e.js
+++ b/discord-e2e.js
@@ -275,3 +275,16 @@ function checkUserScroll(changes, observer) {
         decryptLastMessages(document.getElementsByClassName("markup-2BOw-j").length)
     }
 }
+
+// Check location.href each 50ms interval to load new keys if needed
+var oldUrl = location.href
+setInterval(() => {
+		var newUrl = location.href
+    if( oldUrl != newUrl){
+    		console.log("[+] URL changing ...")
+      	loadKeys()
+      	oldUrl = newUrl
+    } else{
+      	console.log("[+] No URL changing ...")
+    }
+}, 50)


### PR DESCRIPTION
In my last test the userscript didn't refresh when the url change.

The only way I find to make it work is using an interval check, I tried few other method with event listener but it didn't worked.