### PR TITLE
Use PBDKF2 for make a derivation from a password instead to just generate a key

### DIFF
--- a/generate-key.js
+++ b/generate-key.js
@@ -2,35 +2,29 @@
     This script should be only run into the dev console
     More information: https://github.com/mpgn/discord-e2e-encryption
 */
-
-async function generateKey(password, salt, iterations) {
-    // Based on https://8gwifi.org/docs/window-crypto-pbkdf.jsp
-
-    // Define the different part for the key
-    let saltEncoder = new TextEncoder('utf-8')
-    let saltBuffer = saltEncoder.encode(salt)
-    let encoder = new TextEncoder('utf-8')
-    let passphraseKey = encoder.encode(password)
-
-    let key = await window.crypto.subtle.importKey(
-        'raw',
-        passphraseKey,
-        {name: 'PBKDF2'},
+async function generateKey(passphrase, salt){
+    // Import password as CryptoKey object
+    let enc = new TextEncoder()
+    let masterkey = await window.crypto.subtle.importKey(
+        "raw",
+        enc.encode(passphrase),
+        {name: "PBKDF2"},
         false,
-        ['deriveBits', 'deriveKey']
+        ["deriveBits", "deriveKey"]
     )
 
     return window.crypto.subtle.deriveKey(
-        { "name": 'PBKDF2',
-          "salt": saltBuffer,
-          "iterations": iterations,
-          "hash": 'SHA-256'
-        },
-        key,
-        { "name": 'AES-CBC', "length": 256 },
-        true,
-        [ "encrypt", "decrypt" ]
-    )
+      {
+        "name": "PBKDF2",
+        salt: enc.encode(salt),
+        "iterations": 100000,
+        "hash": "SHA-256"
+      },
+      masterkey,
+      { "name": "AES-GCM", "length": 256},
+      false,
+      [ "encrypt", "decrypt" ]
+    );
 }
 
 async function exportKey(key) {
@@ -40,7 +34,7 @@ async function exportKey(key) {
     )
 }
 
-var key = await generateKey("your password", "your salt", 10000)
+var key = await generateKey("your password", "your salt")
 exportKey(key).then(function (result) {
     console.log(result)
 })

--- a/generate-key.js
+++ b/generate-key.js
@@ -3,11 +3,12 @@
     More information: https://github.com/mpgn/discord-e2e-encryption
 */
 
-async function generateKey(password, iterations) {
+async function generateKey(password, salt, iterations) {
     // Based on https://8gwifi.org/docs/window-crypto-pbkdf.jsp
 
     // Define the different part for the key
-    let saltBuffer = crypto.getRandomValues(new Uint8Array(8))
+    let saltEncoder = new TextEncoder('utf-8')
+    let saltBuffer = saltEncoder.encode(salt)
     let encoder = new TextEncoder('utf-8')
     let passphraseKey = encoder.encode(password)
 
@@ -39,7 +40,7 @@ async function exportKey(key) {
     )
 }
 
-var key = await generateKey("your password", 10000)
+var key = await generateKey("your password", "your salt", 10000)
 exportKey(key).then(function (result) {
     console.log(result)
 })


### PR DESCRIPTION
It could be more practical way to use a password (and maybe a defined salt) from the interface to generate the key and display them.

It's also more easier to send passphrase and a salt than a big key.
Right now it juste use PBKDF2 with a random salt.

It looks like working, but I'm not completely sure about the "raw" and "jwk" format. I didn't change anything about the IV, but maybe it need to be change with PBKDF2.